### PR TITLE
build headers

### DIFF
--- a/scripts/build-common
+++ b/scripts/build-common
@@ -4,13 +4,11 @@ set -e
 : ${KERNEL_URL:="https://github.com/rancher/linux/archive/Ubuntu-3.19.0-27.29.tar.gz"}
 : ${KERNEL_SHA1:="84b9bc53bbb4dd465b97ea54a71a9805e27ae4f2"}
 : ${ARTIFACTS:=$(pwd)/assets}
-: ${BUILD:=$(pwd)/build}
+: ${BUILD:=/usr/src}
 : ${CONFIG:=$(pwd)/config}
 : ${DIST:=$(pwd)/dist}
 
 DOCKER_FILE=${CONFIG}/.dockerfile
-
-mkdir -p ${BUILD} ${DIST}
 
 write_base()
 {
@@ -111,4 +109,11 @@ download()
         echo "ERROR: $file does not match checksum $hash, got $CURRENT" 1>&2
         return 1
     fi
+}
+
+list_build_files() {
+    find . -name Makefile\* -o -name Kconfig\* -o -name \*.pl
+    find $(find ./arch/${SRCARCH} -name include -o -name scripts -type d) ./include ./scripts -type f
+    find ./arch/${SRCARCH} -name module.lds -o -name Kbuild.platforms -o -name Platform
+    find . -name Module.symvers -type f
 }

--- a/scripts/build-kernel
+++ b/scripts/build-kernel
@@ -1,10 +1,9 @@
 #!/bin/bash
+set -e
 
 cd $(dirname $0)/..
 
 source scripts/build-common
-
-apt-get install -y build-essential libncurses5-dev bc ccache
 
 export CCACHE_DIR="${HOME}/.kernel-ccache"
 export CC="ccache gcc"
@@ -12,6 +11,7 @@ export PATH="/usr/lib/ccache:$PATH"
 KERNEL=$(basename ${KERNEL_URL})
 DIR=${KERNEL/.tar.*//}
 
+mkdir -p ${BUILD}
 cd ${BUILD}
 
 if [ ! -e ${DIR} ]; then
@@ -31,7 +31,9 @@ cp ${CONFIG}/kernel-config .config
 make oldconfig
 make -j$(nproc) tar-pkg
 
+list_build_files | tar -czf build.tar.gz -T /dev/stdin
+
 mkdir -p ${DIST}/kernel
 mv linux*.tar ${DIST}/kernel
 gzip ${DIST}/kernel/linux*.tar
-make headers_install INSTALL_HDR_PATH=${DIST}/kernel/headers
+mv build.tar.gz ${DIST}/kernel


### PR DESCRIPTION
Package build.tar.gz that contains the files needed to build 
DKMS modules. The tarball should get unpacked into a directory 
pointed by `/lib/modules/$(uname -r)/build`