### PR TITLE
Add the missing file scripts/firmware

### DIFF
--- a/scripts/ci
+++ b/scripts/ci
@@ -10,6 +10,7 @@ source scripts/build-common
 run --assets ./scripts/build-common \
     ./scripts/bootstrap
 run ./scripts/download
+run --assets ./scripts/firmware
 run --assets ./config/kernel-config \
     ./scripts/build-kernel
 


### PR DESCRIPTION
when build kernel and run the following command:
    `create_firmware_tar /source/scripts/firmware`
will cause error:
	scripts/build-common: line 140: /source/scripts/firmware: No such file or directory

This patch fix that by copy firmware file into container.

Signed-off-by: Wang Long <long.wanglong@huawei.com>