### PR TITLE
Allow to hook in script that builds custom drivers

### DIFF
--- a/scripts/ci
+++ b/scripts/ci
@@ -5,4 +5,5 @@ cd $(dirname $0)/..
 
 ./scripts/download
 ./scripts/extract
+run-parts -v ./scripts/hooks
 ./scripts/build-kernel

--- a/scripts/hooks/01-example-driver
+++ b/scripts/hooks/01-example-driver
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# This should be an excutable shell script, which builds your customized driver in to kernel.
+#
+# To minimize maintenance, it is better to be self-sufficent, or with minimum external dependencies.
+# e.g.  gcc mydriver.c
+#
+# A real world example is shown at https://github.com/rancher/os-kernel/commit/93b71d24fb6368d38f562184d6fb5a97926265df
+#


### PR DESCRIPTION
If you have a script that build a custom driver, you could place it
in scripts/hooks directory, the ci script will build it in order.

I have a commit at https://github.com/liyimeng/os-kernel/commit/93b71d24fb6368d38f562184d6fb5a97926265df  which build zfs into kernel to demonstrate the usage. 

Please note that building ZFS into kernel violate GPL and CDDL license. Do not take this commit(93b71d24) into your production!  
