### PR TITLE
Fixed kvm: Unknown symbol irq_bypass_register_consumer (err 0)

### DIFF
--- a/modules-extra.list
+++ b/modules-extra.list
@@ -3835,4 +3835,3 @@ kernel/sound/usb/snd-usbmidi-lib.ko
 kernel/sound/usb/usx2y/snd-usb-us122l.ko
 kernel/sound/usb/usx2y/snd-usb-usx2y.ko
 kernel/ubuntu/i915/i915_bpo.ko
-kernel/virt/lib/irqbypass.ko

--- a/modules.list
+++ b/modules.list
@@ -845,3 +845,4 @@ kernel/net/vmw_vsock/vsock.ko
 kernel/net/xfrm/xfrm_algo.ko
 kernel/net/xfrm/xfrm_ipcomp.ko
 kernel/net/xfrm/xfrm_user.ko
+kernel/virt/lib/irqbypass.ko


### PR DESCRIPTION
Caused KVM host failure when no extra modules pack used, what may be a problem even on cloud guests where nested KVM supported by host and used by guest