### PR TITLE
Enable cdc-acm kernel module

### DIFF
--- a/config/kernel-config
+++ b/config/kernel-config
@@ -3910,7 +3910,7 @@ CONFIG_USB_HCD_SSB=m
 #
 # USB Device Class drivers
 #
-# CONFIG_USB_ACM is not set
+CONFIG_USB_ACM=m
 # CONFIG_USB_PRINTER is not set
 # CONFIG_USB_WDM is not set
 # CONFIG_USB_TMC is not set


### PR DESCRIPTION
Very much needed for serial USB devices.
