### PR TITLE
Build an rancher/os-kernel image in the form that moby wants it

### DIFF
--- a/images/10-kernel/Dockerfile
+++ b/images/10-kernel/Dockerfile
@@ -1,0 +1,18 @@
+#FROM alpine:3.4
+## FROM arm64=skip arm=skip
+#RUN apk --purge --no-cache add kmod bash
+
+
+FROM linuxkit/toybox-media:eee3dd4d72cd784801e95b1781e6c4f9d8a5e5eb@sha256:7f940e687164ee2676e11c61705c79f7dd2d144ee87ad17a494848a7045f5f53
+ARG KERNEL_VERSION
+ENV KERNEL_VERSION=${KERNEL_VERSION}
+ENTRYPOINT []
+CMD []
+WORKDIR /
+COPY /kernel /
+COPY /System.map /
+#COPY kernel-headers.tar /
+COPY /kernel.tar /
+#COPY kernel-dev.tar /
+#COPY kernel-source-info /
+

--- a/images/10-kernel/prebuild.sh
+++ b/images/10-kernel/prebuild.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -ex
+
+# linux-${KERNEL_VERSION}-x86.tar
+
+tar -xf /source/dist/kernel/linux-${KERNEL_VERSION}-x86.tar.gz  ./boot/vmlinuz-${KERNEL_VERSION} ./boot/System.map-${KERNEL_VERSION}
+mv ./boot/vmlinuz-${KERNEL_VERSION} ./images/10-kernel/kernel
+mv ./boot/System.map-${KERNEL_VERSION} ./images/10-kernel/System.map
+rmdir boot
+
+cp /source/dist/kernel/linux-${KERNEL_VERSION}-x86.tar.gz ./images/10-kernel/kernel.tar.gz
+gunzip -f ./images/10-kernel/kernel.tar.gz
+
+ls -lah ./images/10-kernel


### PR DESCRIPTION
I'm not really convinced that 

```
+FROM linuxkit/toybox-media:eee3dd4d72cd784801e95b1781e6c4f9d8a5e5eb@sha256:7f940e687164ee2676e11c61705c79f7dd2d144ee87ad17a494848a7045f5f53
```

is the right base image for us to use - but its what they're using in linuxkit atm