### PR TITLE
Add support for vfat formatted config drive

### DIFF
--- a/modules-extra.list
+++ b/modules-extra.list
@@ -3426,7 +3426,6 @@ kernel/fs/nls/nls_euc-jp.ko
 kernel/fs/nls/nls_iso8859-13.ko
 kernel/fs/nls/nls_iso8859-14.ko
 kernel/fs/nls/nls_iso8859-15.ko
-kernel/fs/nls/nls_iso8859-1.ko
 kernel/fs/nls/nls_iso8859-2.ko
 kernel/fs/nls/nls_iso8859-3.ko
 kernel/fs/nls/nls_iso8859-4.ko

--- a/modules.list
+++ b/modules.list
@@ -471,6 +471,7 @@ kernel/fs/nfs/nfsv3.ko
 kernel/fs/nfs/nfsv4.ko
 kernel/fs/nls/nls_ascii.ko
 kernel/fs/nls/nls_cp437.ko
+kernel/fs/nls/nls_iso8859-1.ko
 kernel/fs/nls/nls_utf8.ko
 kernel/fs/overlayfs/overlay.ko
 kernel/fs/quota/quota_tree.ko


### PR DESCRIPTION
PR to resolve rancher/os#1643

Mounting a vfat formatted config drive requires the nls_iso8859-1 kernel module.