### PR TITLE
Error when download keysign via ipv6

### DIFF
--- a/scripts/download
+++ b/scripts/download
@@ -16,7 +16,11 @@ curl -sL ${KERNEL_URL}${KERNEL_SIGN} > ${KERNEL_SIGN}
 
 # grab gregkh's stable signing key
 GPG_KEY="6092693E"
+set +e
 gpg2 --keyserver hkp://keys.gnupg.net --recv-keys $GPG_KEY
+[ $? -ne 0 ] && echo "gpg2 key sign download failed. trying second mirror"
+set -e
+gpg2 --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys $GPG_KEY
 
 if ! xz -cd ${KERNEL_TAR} | gpg2 --verify ${KERNEL_SIGN} - ; then
     echo "ERROR: ${KERNEL_TAR} signing error" 1>&2


### PR DESCRIPTION
Error Message:
"gpg: keyserver receive failed: Cannot assign requested address"

Root Cause:
When you try to `make release` keys.gnupg.net may be resolved to an IPv6 address. Under some circumstances (e.g. an internet connection that does not support IPv6) the build sistematically fail with message:
"gpg: keyserver receive failed: Cannot assign requested address"

Solution:
I created a fallback to an IPv4 version of keyserver.