### PR TITLE
Fix mtu issue in Xen

### DIFF
--- a/patches/xen-netfront-Fix-mismatched-rtnl_unlock.patch
+++ b/patches/xen-netfront-Fix-mismatched-rtnl_unlock.patch
@@ -1,0 +1,21 @@
+diff --git a/drivers/net/xen-netfront.c b/drivers/net/xen-netfront.c
+index d5e790dd589a..d7dc95f58dae 100644
+--- a/drivers/net/xen-netfront.c
++++ b/drivers/net/xen-netfront.c
+@@ -1817,7 +1817,7 @@ static int talk_to_netback(struct xenbus_device *dev,
+ 	err = xen_net_read_mac(dev, info->netdev->dev_addr);
+ 	if (err) {
+ 		xenbus_dev_fatal(dev, err, "parsing %s/mac", dev->nodename);
+-		goto out;
++		goto out_unlocked;
+ 	}
+ 
+ 	rtnl_lock();
+@@ -1932,6 +1932,7 @@ static int talk_to_netback(struct xenbus_device *dev,
+ 	xennet_destroy_queues(info);
+  out:
+ 	rtnl_unlock();
++out_unlocked:
+ 	device_unregister(&dev->dev);
+ 	return err;
+ }

--- a/patches/xen-netfront-Update-features-after-registering-netde.patch
+++ b/patches/xen-netfront-Update-features-after-registering-netde.patch
@@ -1,0 +1,26 @@
+diff --git a/drivers/net/xen-netfront.c b/drivers/net/xen-netfront.c
+index d7dc95f58dae..31bc4210f969 100644
+--- a/drivers/net/xen-netfront.c
++++ b/drivers/net/xen-netfront.c
+@@ -1958,10 +1958,6 @@ static int xennet_connect(struct net_device *dev)
+ 	/* talk_to_netback() sets the correct number of queues */
+ 	num_queues = dev->real_num_tx_queues;
+ 
+-	rtnl_lock();
+-	netdev_update_features(dev);
+-	rtnl_unlock();
+-
+ 	if (dev->reg_state == NETREG_UNINITIALIZED) {
+ 		err = register_netdev(dev);
+ 		if (err) {
+@@ -1971,6 +1967,10 @@ static int xennet_connect(struct net_device *dev)
+ 		}
+ 	}
+ 
++	rtnl_lock();
++	netdev_update_features(dev);
++	rtnl_unlock();
++
+ 	/*
+ 	 * All public and private state should now be sane.  Get
+ 	 * ready to start sending and receiving packets and give the driver


### PR DESCRIPTION
Something has broken MTU functionality in Xen: specifically,
setting MTUs larger than 1500 fails. This prevents Jumbo Frames and other
features which require larger than 1500 byte MTUs from being used. This can
lead to a failure to sync/connect to other components in the cluster/cloud
which expect higher MTUs and result in unavailable services.

The issue is caused by the following commit to the xen-netfront driver:
"xen-netfront: Fix race between device setup and open"
commit f599c64fdf7d9c108e8717fb04bc41c680120da4

The following commits fix this issue in the mainline kernel:

"xen-netfront: Fix mismatched rtnl_unlock"
commit cb257783c2927b73614b20f915a91ff78aa6f3e8
"xen-netfront: Update features after registering netdev"
commit 45c8184c1bed1ca8a7f02918552063a00b909bf5


Related issue: https://github.com/rancher/os/issues/2458