### PR TITLE
Built-in intel wifi driver

### DIFF
--- a/modules-extra.list
+++ b/modules-extra.list
@@ -3348,9 +3348,7 @@ kernel/drivers/net/wireless/cisco/airo.ko
 kernel/drivers/net/wireless/intel/ipw2x00/ipw2100.ko
 kernel/drivers/net/wireless/intel/ipw2x00/libipw.ko
 kernel/drivers/net/wireless/intel/ipw2x00/ipw2200.ko
-kernel/drivers/net/wireless/intel/iwlwifi/iwlwifi.ko
 kernel/drivers/net/wireless/intel/iwlwifi/dvm/iwldvm.ko
-kernel/drivers/net/wireless/intel/iwlwifi/mvm/iwlmvm.ko
 kernel/drivers/net/wireless/intel/iwlegacy/iwl3945.ko
 kernel/drivers/net/wireless/intel/iwlegacy/iwlegacy.ko
 kernel/drivers/net/wireless/intel/iwlegacy/iwl4965.ko

--- a/modules.list
+++ b/modules.list
@@ -890,3 +890,5 @@ kernel/drivers/net/ethernet/amazon/ena/ena.ko
 kernel/drivers/mmc/host/sdhci-acpi.ko
 kernel/drivers/mmc/host/sdhci.ko
 kernel/drivers/mmc/core/mmc_block.ko
+kernel/drivers/net/wireless/intel/iwlwifi/iwlwifi.ko
+kernel/drivers/net/wireless/intel/iwlwifi/mvm/iwlmvm.ko

--- a/scripts/firmware
+++ b/scripts/firmware
@@ -54,3 +54,11 @@ myri10ge_ethp_z8e.dat
 bnx2x/bnx2x-e1-7.13.1.0.fw
 bnx2x/bnx2x-e2-7.13.1.0.fw
 bnx2x/bnx2x-e1h-7.13.1.0.fw
+iwlwifi-3160-17.ucode
+iwlwifi-3168-29.ucode
+iwlwifi-7260-17.ucode
+iwlwifi-7265D-29.ucode
+iwlwifi-8000C-36.ucode
+iwlwifi-8265-36.ucode
+iwlwifi-9000-pu-b0-jf-b0-41.ucode
+iwlwifi-9260-th-b0-jf-b0-41.ucode


### PR DESCRIPTION
## Built-in intel wifi driver (rancher/os#2370)

### Built-in modules:
- [x] `iwlwifi`
- [x] `iwlmvm`
- ~`iwldvm` which  not embedded by defult, because we have no embedded firmware to use it. [link](https://wireless.wiki.kernel.org/en/users/drivers/iwlwifi#firmware)~
### Built-in firmwares:
- [x] iwlwifi-3160-17.ucode  - iwlmvm
- [x] iwlwifi-3168-29.ucode - iwlmvm
- [x] iwlwifi-7260-17.ucode - iwlmvm
- [x] iwlwifi-7265D-29.ucode - iwlmvm
- [x] iwlwifi-8000C-36.ucode - iwlmvm
- [x] iwlwifi-8265-36.ucode - iwlmvm
- [x] iwlwifi-9000-pu-b0-jf-b0-41.ucode -iwlmvm
- [x] iwlwifi-9260-th-b0-jf-b0-41.ucode -iwlmvm

