### PR TITLE
Add support for PCIe eMMC host controllers

### DIFF
--- a/modules/x86/modules-extra.list
+++ b/modules/x86/modules-extra.list
@@ -1661,7 +1661,6 @@ kernel/drivers/mmc/host/cb710-mmc.ko
 kernel/drivers/mmc/host/cqhci.ko
 kernel/drivers/mmc/host/mmc_spi.ko
 kernel/drivers/mmc/host/mtk-sd.ko
-kernel/drivers/mmc/host/sdhci-pci.ko
 kernel/drivers/mmc/host/sdhci-pltfm.ko
 kernel/drivers/mmc/host/tifm_sd.ko
 kernel/drivers/mmc/host/toshsd.ko

--- a/modules/x86/modules.list
+++ b/modules/x86/modules.list
@@ -230,6 +230,7 @@ kernel/drivers/misc/vmw_balloon.ko
 kernel/drivers/misc/vmw_vmci/vmw_vmci.ko
 kernel/drivers/mmc/core/mmc_block.ko
 kernel/drivers/mmc/host/sdhci-acpi.ko
+kernel/drivers/mmc/host/sdhci-pci.ko
 kernel/drivers/mmc/host/sdhci.ko
 kernel/drivers/net/bonding/bonding.ko
 kernel/drivers/net/dummy.ko


### PR DESCRIPTION
Some computers have eMMC storage exposed through PCIe eMMC host controllers. The use of these storage devices requires the `sdhci-pci` kernel module to be loaded.

Currently, `sdhci-pci` is only available in kernel-extras, so we probably won't be able to boot off eMMC on those computers (e.g. Intel NUC7CJYS). This pull request moves the `sdhci-pci` module to modules.list so the eMMC will be visible from boot.

Tested on an HP t430, which has eMMC on an Intel PCIe eMMC host controller.